### PR TITLE
Added a getRWState

### DIFF
--- a/src/NFCReaderWriter.cpp
+++ b/src/NFCReaderWriter.cpp
@@ -148,4 +148,9 @@ void NFCReaderWriter::run()
         }
     }
 
+ReaderWriterState NFCReaderWriter::getRWState()
+{
+    return theState;
+}
+
 

--- a/src/NFCReaderWriter.h
+++ b/src/NFCReaderWriter.h
@@ -35,6 +35,7 @@ class NFCReaderWriter
         NFCReaderWriter(NCI &theNCI);						// constructor
         void initialize();									// initialize the Reader/Writer application. Will in its turn initialize the NCI layer and the HW interface on which the application relies
         void run();
+		ReaderWriterState getRWState();						// returns the actual state to trigger events like a sound
     };
 
 #endif


### PR DESCRIPTION
Added this function:
      ReaderWriterState getRWState();						

Which makes it possible to trigger events like a sound.

In this example I uses a charliewing from adafruit to test the behaviour:

```
void loop()
{
  theReaderWriter.run(); // give the application object some CPU time to do its job. This is a non-blocking function
  ReaderWriterState newState = theReaderWriter.getRWState();
  if (OldState != newState)
  {
    OldState = newState;
    switch (newState)
    {
    case ReaderWriterState::initializing:
      Serial.println("initializing");
      drawSad();
      break;
    case ReaderWriterState::singleTagPresent:
      Serial.println("single tag present");
      drawSmily();
      break;
    case ReaderWriterState::multipleTagsPresent:
      Serial.println("multiple tags present");
      drawSmily();
      break;
    case ReaderWriterState::noTagPresent:
      Serial.println("not tag present");
      drawNeutral();
      break;
    default:
      drawNeutral();
      Serial.println("exeption");
      break;
    }
  }
}
```